### PR TITLE
added before and after hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Template.layout.animations({
     container: ".container", // container of the ".item" elements
     in: "fade-in", // class applied to inserted elements
     out: "fade-out", // class applied to removed elements
-    inCallback: function(element) {}, // callback after an element gets inserted
-    outCallback: function(element) {}, // callback after an element gets removed
+    beforeIn: function(attrs, element, template) {}, // callback before the insert animation is triggered
+    beforeOut: function(attrs, element, template) {}, // callback before the remove animation is triggered
+    afterIn: function(attrs, element, template) {}, // callback after an element gets inserted
+    afterOut: function(attrs, element, template) {}, // callback after an element gets removed
     delayIn: 500, // Delay before inserted items animate
     delayOut: 500, // Delay before removed items animate
     animateInitial: true, // animate the elements already rendered

--- a/lib.js
+++ b/lib.js
@@ -26,6 +26,7 @@ var animateIn = function(attrs, element, tpl) {
   element.css({ opacity: 0, transition: "none" });
   element.removeClass(classIn);
   var delayIn = attrs.delayIn || 0;
+  attrs.beforeIn && attrs.beforeIn.apply(this, [attrs, element, tpl]);
   Tracker.afterFlush(function() {
     setTimeout(function() {
       element.css({ opacity: element._opacity, transition: element._transition }).addClass(classIn).addClass(Anim.insertingClass);
@@ -40,6 +41,7 @@ var animateOut = function(attrs, element, tpl) {
   var classOut = getClassOut(attrs, el, tpl);
   var delayOut = attrs.delayOut || 0;
   element.removeClass(classIn).addClass(Anim.removingClass);
+  attrs.beforeOut && attrs.beforeOut.apply(this, [attrs, element, tpl]);
   setTimeout(function() {
     element.addClass(classOut);
   }, delayOut);
@@ -59,12 +61,20 @@ var attachAnimationCallbacks = function(attrs, selector, tpl) {
     // Insert
     if (element.hasClass(Anim.insertingClass)) {
       element.removeClass(Anim.insertingClass).addClass(Anim.insertedClass);
-      attrs.inCallback && attrs.inCallback.call(this);
+      if(attrs.inCallback) {
+        console.warn('inCallback is deprecated. Please use afterIn instead');
+        attrs.inCallback.call(this);
+      }
+      attrs.afterIn && attrs.afterIn.apply(this, [attrs, element, tpl]);
     }
 
     // Remove
     if (element.hasClass(Anim.removingClass)) {
-      attrs.outCallback && attrs.outCallback.call(this);
+      if(attrs.outCallback) {
+        console.warn('outCallback is deprecated. Please use afterOut instead');
+        attrs.outCallback.call(this);
+      }
+      attrs.afterOut && attrs.afterOut.apply(this, [attrs, element, tpl]);
       element.remove();
     }
 


### PR DESCRIPTION
I've implemented `beforeIn` and `beforeOut` hooks and renamed `inCallback` and `outCallback` to `afterIn` and `afterOut`.
Additionally I've added a deprecation warning if `inCallback` or `outCallback` is called.
